### PR TITLE
re BACK-3133: work around the invalid javascript contained in the gce platform info json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node"
   ],
   "dependencies": {
-    "google-custom-metrics": "0.10.1"
+    "google-custom-metrics": "0.12.0"
   },
   "devDependencies": {
     "eslint": "3.19.0",


### PR DESCRIPTION
Upgrade to `google-custom-metrics@0.12.0` to fix the host id.

The GCE platform info returned by `http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true` contains a numeric host id that overflows a JavaScript Number, and the resulting mismatch causes stats uploads to fail.  If handled as a string, however, uploads succeed.