### PR TITLE
Back 3254 prometheus endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 0.3.0
+* new `Prometheus` backend
+
 ### 0.2.1
 * moved google-custom-metrics dependency
 

--- a/README.md
+++ b/README.md
@@ -286,4 +286,10 @@ Backend Options
 * `statsMap` A JSON object containing keys indicating the name of the stats in stats-logger, mapped to the values of StackDriver
   custom metrics
 
+### Prometheus
 
+The PrometheusDriver backend exposes the stats to Prometheus polls
+
+Backend Options
+* `port` - port to expose to prometheus, default 9091
+* `sameProcess` - whether to listen for metrics in the same process or fork a worker, default `true` same process

--- a/lib/backends/Prometheus.js
+++ b/lib/backends/Prometheus.js
@@ -1,0 +1,45 @@
+// Copyright 2018 Kinvey, Inc
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+'use strict';
+
+var StackDriver = require('./StackDriver');
+var prometheusGateway = require('prom-pushgateway');
+var gateway = null;
+
+// use prom-pushgateway in stackdriver mode
+module.exports.connect = function prometheusConnect( emitter, userConfig ) {
+  var config = {};
+  for (var k in userConfig) config[k] = userConfig[k];
+
+  config.apiKey = 'not empty but not needed';
+
+  // provide stackdriver config settings
+  config.stackDriverPort = userConfig.port || 9091;
+  config.stackDriverHost = userConfig.host || 'localhost';
+  config.stackDriverPath = userConfig.path || '/push/stackdriver';
+
+  var backend = config.stackDriverBackend || StackDriver.connect(emitter, config);
+
+  config.listenTimeout = 30;
+
+  if (!gateway) {
+    var createServerCall = (userConfig.sameProcess === undefined || userConfig.sameProcess) ? 'createServer' : 'forkServer';
+    gateway = prometheusGateway[createServerCall](config, function(err, info) {
+      if (err) throw err;
+    })
+  }
+
+  return backend;
+}

--- a/lib/backends/Prometheus.js
+++ b/lib/backends/Prometheus.js
@@ -16,9 +16,9 @@
 
 var StackDriver = require('./StackDriver');
 var prometheusGateway = require('prom-pushgateway');
-var gateway = null;
 
-// use prom-pushgateway in stackdriver mode
+// use prom-pushgateway to create a prometheus scrapable endpoint
+// that re-exports the pushed legacy stackdriver metrics
 module.exports.connect = function prometheusConnect( emitter, userConfig ) {
   var config = {};
   for (var k in userConfig) config[k] = userConfig[k];
@@ -29,16 +29,19 @@ module.exports.connect = function prometheusConnect( emitter, userConfig ) {
   config.stackDriverPort = userConfig.port || 9091;
   config.stackDriverHost = userConfig.host || 'localhost';
   config.stackDriverPath = userConfig.path || '/push/stackdriver';
+  config.statsMap = userConfig.statsMap || {};
 
   var backend = config.stackDriverBackend || StackDriver.connect(emitter, config);
 
   config.listenTimeout = 30;
 
-  if (!gateway) {
-    var createServerCall = (userConfig.sameProcess === undefined || userConfig.sameProcess) ? 'createServer' : 'forkServer';
-    gateway = prometheusGateway[createServerCall](config, function(err, info) {
-      if (err) throw err;
-    })
+  if (userConfig.sameProcess) {
+    backend._gateway = prometheusGateway.createServer(config, function(err, info) { if (err) throw err })
+    backend.close = function close(cb) { backend._gateway.close(cb) }
+  }
+  else {
+    backend._gateway = prometheusGateway.forkServer(config, function(err, info) { if (err) throw err })
+    backend.close = function close(cb) { backend._gateway.pid && process.kill(backend._gateway.pid) }
   }
 
   return backend;

--- a/lib/backends/Prometheus.js
+++ b/lib/backends/Prometheus.js
@@ -16,6 +16,11 @@
 
 var StackDriver = require('./StackDriver');
 var prometheusGateway = require('prom-pushgateway');
+try {
+    // the Prometheus backend optionally includes prom-client default stats
+    var promClient = require('prom-client');
+    promClient.collectDefaultMetrics();
+} catch (err) { }
 
 // use prom-pushgateway to create a prometheus scrapable endpoint
 // that re-exports the pushed legacy stackdriver metrics
@@ -33,14 +38,30 @@ module.exports.connect = function prometheusConnect( emitter, userConfig ) {
 
   var backend = config.stackDriverBackend || StackDriver.connect(emitter, config);
 
-  config.listenTimeout = 30;
+  // allow 5 seconds for the prom gateway to start, else emit error
+  config.listenTimeout = 5;
+
+  // include prom-client default metrics if available
+  if (promClient) config.readPromMetrics = function() { return promClient.register.metrics() };
+
+  // cater to Prometheus limitations
+  config.port = userConfig.port || 9091;
+  config.maxMetricAgeMs = 60000;        // only report fresh metrics
+  config.omitTimestamps = true;         // let prometheus attach its own metric-collected-at timestamps
+  config.anyPort = true;                // if config.port is not available, listen on some other port
 
   if (userConfig.sameProcess) {
-    backend._gateway = prometheusGateway.createServer(config, function(err, info) { if (err) throw err })
+    backend._gateway = prometheusGateway.createServer(config, function(err, info) {
+      if (err) return emitter.emit('error', err);
+      backend.stackDriverPort = info.port;
+    })
     backend.close = function close(cb) { backend._gateway.close(cb) }
   }
   else {
-    backend._gateway = prometheusGateway.forkServer(config, function(err, info) { if (err) throw err })
+    backend._gateway = prometheusGateway.forkServer(config, function(err, info) {
+      if (err) return emitter.emit('error', err);
+      backend.stackDriverPort = info.port;
+    })
     backend.close = function close(cb) { backend._gateway.pid && process.kill(backend._gateway.pid) }
   }
 

--- a/lib/backends/StackDriver.js
+++ b/lib/backends/StackDriver.js
@@ -15,6 +15,7 @@
 "use strict";
 
 var https = require('https'),
+  http = require('http'),
   StackDriverBackend;
 
 /**
@@ -40,6 +41,7 @@ exports.connect = function(emitter, config) {
     this.statsMap = config.statsMap || {};
     this.stackDriverHost = config.stackDriverHost || 'custom-gateway.stackdriver.com';
     this.stackDriverPath = config.stackDriverPath || '/v1/custom';
+    this.stackDriverPort = config.stackDriverPort || 443;
     this.userAgent = 'stackdriver-stats-logger-backend/' + require('../../package.json').version;
 
     emitter.on('flush', flush);
@@ -92,6 +94,7 @@ exports.connect = function(emitter, config) {
     var options = {
       host : self.stackDriverHost,
       path : self.stackDriverPath,
+      port : self.stackDriverPort,
       method : 'POST',
       headers : {
         "Content-Length" : message.length,
@@ -102,7 +105,8 @@ exports.connect = function(emitter, config) {
     };
 
     // perform the HTTPS request
-    var req = https.request(options, function(res) {
+    var request = (options.port === 443) ? https.request : http.request;
+    var req = request(options, function(res) {
       // 4xx and 5xx errors
       if (Math.floor(res.statusCode / 100) === 4 || Math.floor(res.statusCode / 100) === 5){
         self.emitter.emit('error', res.statusCode + " error sending to Stackdriver");

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "google-custom-metrics": "0.12.0",
-    "prom-pushgateway": "0.6.4"
+    "prom-pushgateway": "0.10.0"
   },
   "devDependencies": {
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "node"
   ],
   "dependencies": {
-    "google-custom-metrics": "0.12.0"
+    "google-custom-metrics": "0.12.0",
+    "prom-pushgateway": "0.6.1"
   },
   "devDependencies": {
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "google-custom-metrics": "0.12.0",
-    "prom-pushgateway": "0.6.2"
+    "prom-pushgateway": "0.6.4"
   },
   "devDependencies": {
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-logger",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A lightweight application stats tracker and logger",
   "main": "index.js",
   "author": "Kinvey <support@kinvey.com>",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "google-custom-metrics": "0.12.0",
-    "prom-pushgateway": "0.6.1"
+    "prom-pushgateway": "0.6.2"
   },
   "devDependencies": {
     "eslint": "3.19.0",

--- a/test/test-backends.js
+++ b/test/test-backends.js
@@ -559,5 +559,22 @@ describe("backends", function() {
       done();
     })
 
+    it ('flush should upload stackdriver metrics to port 9091', function(done) {
+      var promb = prometheusBackend.connect(emitter, { sameProcess: true });
+      var spy = sinon.spy(http, 'request');
+      setTimeout(function() {
+        emitter.emit('flush', {a: 1, b: 2});
+        setTimeout(function(){
+          promb.close();
+          spy.restore();
+          var uri = spy.args[0][0];
+          should.equal(uri.port, 9091);
+          should.equal(uri.hostname, 'localhost');
+          should.equal(uri.path, '/push/stackdriver');
+          done();
+        }, 50);
+      }, 100);
+    })
+
   })
 });

--- a/test/test-backends.js
+++ b/test/test-backends.js
@@ -457,7 +457,7 @@ describe("backends", function() {
     var http = require('http');
     var net = require('net');
 
-    var options = {
+    var stackDriverOptions = {
       stackDriverPort: 9091,
       stackDriverHost: 'localhost',
       statsMap: {},
@@ -470,7 +470,7 @@ describe("backends", function() {
     })
 
     it ('should return a StackDriver backend', function(done) {
-      var stb = stackDriverBackend.connect(emitter, options);
+      var stb = stackDriverBackend.connect(emitter, stackDriverOptions);
       var promb = prometheusBackend.connect(emitter, { port: 13337 });
       var name;
 
@@ -521,7 +521,7 @@ describe("backends", function() {
           promb.close();
           done();
         })
-      }, 100);
+      }, 200);
     })
 
     it ('should default to port 9091', function(done) {
@@ -532,7 +532,7 @@ describe("backends", function() {
           promb.close();
           done();
         })
-      }, 100);
+      }, 200);
     })
 
     it ('should throw on createServer error', function(done) {
@@ -573,7 +573,7 @@ describe("backends", function() {
           should.equal(uri.path, '/push/stackdriver');
           done();
         }, 50);
-      }, 100);
+      }, 200);
     })
 
   })

--- a/test/test-backends.js
+++ b/test/test-backends.js
@@ -22,6 +22,7 @@ var EventEmitter = require('events').EventEmitter,
   fileBackend = require('../lib/backends/file'),
   stackDriverBackend = require('../lib/backends/StackDriver'),
   googleStackDriverBackend = require('../lib/backends/GoogleStackDriver'),
+  prometheusDriverBackend = require('../lib/backends/Prometheus'),
   nock = require('nock');
 
 describe("backends", function() {


### PR DESCRIPTION
this PR makes stats-logger custom stats scrapable by Prometheus.

Create a 'Prometheus' backend and push stats like normal; Prometheus format stats will be accessible at `http://localhost:9091/metrics`